### PR TITLE
Use Content-Length header if available.

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,39 @@ import (
 	"golang.org/x/net/html"
 )
 
+func fetchHtml(url string) *html.Node {
+	// HTTP Get
+	res, err := http.Get(url)
+	if err != nil {
+		fmt.Printf("Unable to fetch url %s\n", url)
+		return nil
+	}
+	defer res.Body.Close()
+
+	// Use Content-Length if available, otherwise use a buffer to determine length
+	r := res.Body
+	if res.ContentLength != -1 {
+		fmt.Printf("Content length: %d\n", res.ContentLength)
+	} else {
+		buffer, err := io.ReadAll(res.Body)
+		if err != nil {
+			fmt.Printf("Error reading content: %s\n", err)
+			return nil
+		}
+		r = io.NopCloser(bytes.NewReader(buffer))
+		fmt.Printf("Content length: %d\n", len(buffer))
+	}
+
+	// Parse body or buffer
+	doc, err := html.Parse(r)
+	if err != nil {
+		fmt.Printf("Error while parsing: %s\n", err)
+		return nil
+	}
+
+	return doc
+}
+
 func main() {
 	if len(os.Args) <= 1 {
 		println("Please provide a url.")
@@ -17,24 +50,7 @@ func main() {
 	}
 
 	url := os.Args[1]
-	res, err := http.Get(url)
-	if err != nil {
-		fmt.Printf("Unable to fetch url %s\n", url)
-		os.Exit(1)
-	}
-	defer res.Body.Close()
+	doc := fetchHtml(url)
 
-	buffer, err := io.ReadAll(res.Body)
-	if err != nil {
-		fmt.Printf("Error reading content: %s\n", err)
-		os.Exit(1)
-	}
-	fmt.Printf("Content length: %d\n", len(buffer))
-
-	doc, err := html.Parse(bytes.NewReader(buffer))
-	if err != nil {
-		fmt.Printf("Error while parsing: %s\n", err)
-		os.Exit(1)
-	}
 	fmt.Printf("%#v\n", doc.FirstChild)
 }

--- a/main.go
+++ b/main.go
@@ -19,25 +19,27 @@ func fetchHtml(url string) *html.Node {
 	}
 	defer res.Body.Close()
 
-	// Use Content-Length if available, otherwise use a buffer to determine length
-	r := res.Body
+	var doc *html.Node
+
+	// Use Content-Length if available, otherwise use a buffer to determine length.
+	// Then, parse the HTML.
 	if res.ContentLength != -1 {
 		fmt.Printf("Content length: %d\n", res.ContentLength)
+		doc, err = html.Parse(res.Body)
+		if err != nil {
+			fmt.Printf("Error parsing HTML: %s", err)
+		}
 	} else {
 		buffer, err := io.ReadAll(res.Body)
 		if err != nil {
 			fmt.Printf("Error reading content: %s\n", err)
 			return nil
 		}
-		r = io.NopCloser(bytes.NewReader(buffer))
 		fmt.Printf("Content length: %d\n", len(buffer))
-	}
-
-	// Parse body or buffer
-	doc, err := html.Parse(r)
-	if err != nil {
-		fmt.Printf("Error while parsing: %s\n", err)
-		return nil
+		doc, err = html.Parse(bytes.NewBuffer(buffer))
+		if err != nil {
+			fmt.Printf("Error parsing HTML: %s", err)
+		}
 	}
 
 	return doc

--- a/milestones.txt
+++ b/milestones.txt
@@ -1,5 +1,6 @@
 [x]  Accept a URL as command line input an fetch the HTML content.
 [x]  Log the size of fetched HTML.
+[ ]  Render the HTML to a new file.
 [ ]  Remove the following elements:
   [ ] script
   [ ] .vector-header


### PR DESCRIPTION
I just realized I removed this feature while fixing my last PR so whoops. Good excuse to neaten up the logic anyways.
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1a0ec8ed8147a2b1c068e85a35ad8041eaabb0d1  | 
|--------|--------|

### Summary:
Reintroduce the use of the `Content-Length` header in `fetchHtml` function to improve HTML parsing efficiency and update milestones.

**Key points**:
- Reintroduce use of `Content-Length` header in `main.go`.
- Modify `fetchHtml` function to check for `Content-Length` and use it if available.
- If `Content-Length` is available, parse HTML directly from `res.Body`.
- If `Content-Length` is not available, read entire body into a buffer and then parse it.
- Handle errors for both reading content and parsing HTML.
- Update `milestones.txt` to include rendering HTML to a new file.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->