### PR TITLE
Traverse Up to Given Depth

### DIFF
--- a/const.go
+++ b/const.go
@@ -1,0 +1,4 @@
+package main
+
+const DEPTH int = 0
+const LINKS_PER_PAGE int = 10

--- a/extractLinks.go
+++ b/extractLinks.go
@@ -4,31 +4,38 @@ import (
 	"golang.org/x/net/html"
 )
 
-func extractLinks(links *[]string, n *html.Node, depth int, maxLinks int) bool {
-	hasLink := false
+func extractLinksClosure(links *[]string, host string, linksPerPage int) func(*html.Node) {
 	numLinks := 0
 
-	// See if current node has a link
-	if n.Type == html.ElementNode && n.Data == "a" {
-		for _, ele := range n.Attr {
-			if ele.Key == "href" {
-				link := httpify(ele.Val)
-				*links = append(*links, link)
-				hasLink = true
-				break
+	var f func(*html.Node)
+	f = func(n *html.Node) {
+		if numLinks >= linksPerPage {
+			return
+		}
+		// See if current node has a link.
+		if n.Type == html.ElementNode && n.Data == "a" {
+			for _, ele := range n.Attr {
+				if ele.Key == "href" {
+					// Relative links will be printed as absolute ones.
+					link := rtoa(ele.Val, host)
+					*links = append(*links, link)
+					numLinks++
+					break
+				}
 			}
+		}
+
+		// Run extractLinks recursively on the first child and its siblings.
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			f(c)
 		}
 	}
 
-	// Run extractLinks recursively on the first child and its siblings
-	for c := n.FirstChild; c != nil; c = c.NextSibling {
-		if extractLinks(links, c, depth-1, maxLinks) {
-			numLinks++
-			if numLinks >= maxLinks {
-				break
-			}
-		}
+	return func(n *html.Node) {
+		f(n)
 	}
+}
 
-	return hasLink
+func extractLinks(links *[]string, n *html.Node, host string, linksPerPage int) {
+	extractLinksClosure(links, host, linksPerPage)(n)
 }

--- a/fetchHtml.go
+++ b/fetchHtml.go
@@ -24,7 +24,7 @@ func fetchHtml(url string) (*html.Node, string) {
 	// Use Content-Length if available, otherwise use a buffer to determine length.
 	// Then, parse the HTML.
 	if res.ContentLength != -1 {
-		fmt.Printf("Content length: %d\n", res.ContentLength)
+		fmt.Printf("%s: %d bytes.\n", url, res.ContentLength)
 		doc, err = html.Parse(res.Body)
 		if err != nil {
 			fmt.Printf("Error parsing HTML: %s", err)
@@ -35,7 +35,7 @@ func fetchHtml(url string) (*html.Node, string) {
 			fmt.Printf("Error reading content: %s\n", err)
 			return nil, ""
 		}
-		fmt.Printf("Content length: %d\n", len(buffer))
+		fmt.Printf("%s: %d bytes.\n", url, len(buffer))
 		doc, err = html.Parse(bytes.NewBuffer(buffer))
 		if err != nil {
 			fmt.Printf("Error parsing HTML: %s", err)

--- a/fetchHtml.go
+++ b/fetchHtml.go
@@ -9,12 +9,13 @@ import (
 	"golang.org/x/net/html"
 )
 
-func fetchHtml(url string) *html.Node {
+// Returns the root node of document and the hostname.
+func fetchHtml(url string) (*html.Node, string) {
 	// HTTP Get
 	res, err := http.Get(url)
 	if err != nil {
 		fmt.Printf("Unable to fetch url %s\n", url)
-		return nil
+		return nil, ""
 	}
 	defer res.Body.Close()
 
@@ -32,14 +33,15 @@ func fetchHtml(url string) *html.Node {
 		buffer, err := io.ReadAll(res.Body)
 		if err != nil {
 			fmt.Printf("Error reading content: %s\n", err)
-			return nil
+			return nil, ""
 		}
 		fmt.Printf("Content length: %d\n", len(buffer))
 		doc, err = html.Parse(bytes.NewBuffer(buffer))
 		if err != nil {
 			fmt.Printf("Error parsing HTML: %s", err)
+			return nil, ""
 		}
 	}
 
-	return doc
+	return doc, res.Request.URL.Host
 }

--- a/fetchHtmlAndLinks.go
+++ b/fetchHtmlAndLinks.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"golang.org/x/net/html"
+)
+
+type DocWithLinks struct {
+	doc   *html.Node
+	url   string
+	links []string
+}
+
+func fetchHtmlAndLinks(url string, docsWithLinks *[]DocWithLinks, depth int, linksPerPage int) {
+	doc, host := fetchHtml(url)
+	if doc == nil {
+		return
+	}
+	links := extractLinks(doc, host, linksPerPage)
+	docWithLinks := DocWithLinks{doc, url, links}
+	*docsWithLinks = append(*docsWithLinks, docWithLinks)
+
+	if depth <= 0 {
+		return
+	}
+
+	for _, link := range links {
+		fetchHtmlAndLinks(link, docsWithLinks, depth-1, linksPerPage)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"path"
 )
 
 func main() {
@@ -14,8 +15,9 @@ func main() {
 	doc, host := fetchHtml(url)
 	var links []string
 
+	os.Mkdir("out", 0777)
 	extractLinks(&links, doc, host, 10)
-	renderHtml(doc, "render.txt")
-	renderLinks(links, "links.txt")
+	renderHtml(doc, path.Join("out", "render.txt"))
+	renderLinks(links, path.Join("out", "links.txt"))
 
 }

--- a/main.go
+++ b/main.go
@@ -1,24 +1,25 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path"
 )
 
 func main() {
-	if len(os.Args) <= 1 {
-		println("Please provide a url.")
+	url, depth, linksPerPage, ok := parseArgs(os.Args)
+	if !ok {
 		os.Exit(1)
 	}
 
-	url := httpify(os.Args[1])
-	doc, host := fetchHtml(url)
-	var links []string
-
-	extractLinks(&links, doc, host, 10)
+	var docs []DocWithLinks
+	fetchHtmlAndLinks(url, &docs, depth, linksPerPage)
 
 	mkOutDir()
-	renderHtml(doc, path.Join("out", "render.txt"))
+	var links []string
+	for i, doc := range docs {
+		renderHtml(doc.doc, doc.url, path.Join("out", fmt.Sprintf("%d.html", i)))
+		links = append(links, doc.links...)
+	}
 	renderLinks(links, path.Join("out", "links.txt"))
-
 }

--- a/main.go
+++ b/main.go
@@ -15,8 +15,9 @@ func main() {
 	doc, host := fetchHtml(url)
 	var links []string
 
-	os.Mkdir("out", 0777)
 	extractLinks(&links, doc, host, 10)
+
+	mkOutDir()
 	renderHtml(doc, path.Join("out", "render.txt"))
 	renderLinks(links, path.Join("out", "links.txt"))
 

--- a/main.go
+++ b/main.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"fmt"
-	"io"
 	"os"
-	"strings"
 )
 
 func main() {
@@ -14,16 +11,11 @@ func main() {
 	}
 
 	url := httpify(os.Args[1])
-	doc := fetchHtml(url)
+	doc, host := fetchHtml(url)
 	var links []string
 
+	extractLinks(&links, doc, host, 10)
 	renderHtml(doc, "render.txt")
-	extractLinks(&links, doc, 2, 10)
+	renderLinks(links, "links.txt")
 
-	s := strings.Join(links, "\n")
-	w, err := os.Create("links.txt")
-	if err != nil {
-		fmt.Printf("Error creating file: %s", err)
-	}
-	io.WriteString(w, s)
 }

--- a/makefile
+++ b/makefile
@@ -1,2 +1,5 @@
 build:
 	go build -o ./bin/scraper
+
+clean:
+	rm ./bin/*

--- a/makefile
+++ b/makefile
@@ -3,3 +3,6 @@ build:
 
 clean:
 	rm ./bin/*
+
+clean-out:
+	rm ./out/*

--- a/milestones.txt
+++ b/milestones.txt
@@ -1,7 +1,7 @@
 [x]  Accept a URL as command line input an fetch the HTML content.
 [x]  Log the size of fetched HTML.
 [x]  Render the HTML to a new file.
-[ ]  Extract links up to specified depth (--depth command line)
+[x]  Extract links up to specified depth (--depth command line)
 [ ]  Remove the following elements:
   [ ] script
   [ ] .vector-header

--- a/mkOutDir.go
+++ b/mkOutDir.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func mkOutDir() {
+	_, err := os.Stat("out")
+
+	if os.IsNotExist(err) {
+		err := os.Mkdir("out", 0777)
+		if err != nil {
+			fmt.Printf("Unable to create output directory: %s\n", err)
+		}
+	}
+}

--- a/mkOutDir.go
+++ b/mkOutDir.go
@@ -9,7 +9,7 @@ func mkOutDir() {
 	_, err := os.Stat("out")
 
 	if os.IsNotExist(err) {
-		err := os.Mkdir("out", 0777)
+		err := os.Mkdir("out", 0755)
 		if err != nil {
 			fmt.Printf("Unable to create output directory: %s\n", err)
 		}

--- a/parseArgs.go
+++ b/parseArgs.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func parseArgs(args []string) (string, int, int, bool) {
+	url, depth, linksPerPage := "", DEPTH, LINKS_PER_PAGE
+	var err error
+	for i := 1; i < len(args); i++ {
+
+		arg := args[i]
+		if strings.HasPrefix(arg, "--") {
+			argKey := arg[2:]
+			i++
+			argValue := args[i]
+
+			switch argKey {
+
+			case "depth":
+				depth, err = strconv.Atoi(argValue)
+				if err != nil {
+					fmt.Printf("Invalid value for depth: '%s'. Depth must be an integer.\n", err)
+					return url, depth, linksPerPage, false
+				}
+
+			case "links":
+				linksPerPage, err = strconv.Atoi(argValue)
+				if err != nil {
+					fmt.Printf("Invalid value for links per page: '%s'. Links per page must be an integer.\n", err)
+					return url, depth, linksPerPage, false
+				}
+
+			default:
+				fmt.Printf("Unrecognized parameter ")
+
+			}
+		} else {
+			if url != "" {
+				fmt.Printf("There must be only one unnamed param for url. Example: scraper google.com --depth 0 --links 5\n")
+				return url, depth, linksPerPage, false
+			} else {
+				url = httpify(arg)
+			}
+		}
+	}
+
+	if url == "" {
+		fmt.Println("url is required. Example: scraper google.com --depth 0 --links 5.")
+		return url, depth, linksPerPage, false
+	}
+
+	return url, depth, linksPerPage, true
+}

--- a/renderHtml.go
+++ b/renderHtml.go
@@ -2,21 +2,23 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"golang.org/x/net/html"
 )
 
-func renderHtml(doc *html.Node, filename string) {
+func renderHtml(doc *html.Node, url string, filename string) {
 	f, err := os.Create(filename)
 	if err != nil {
-		fmt.Printf("Error creating file: %s", err)
+		fmt.Printf("Error creating file: %s\n", err)
 		return
 	}
 
+	io.WriteString(f, fmt.Sprintf("<!-- %s -->", url))
 	err = html.Render(f, doc)
 	if err != nil {
-		fmt.Printf("Error rendering HTML: %s", err)
+		fmt.Printf("Error rendering HTML: %s\n", err)
 		return
 	}
 }

--- a/renderLinks.go
+++ b/renderLinks.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+func renderLinks(links []string, filename string) {
+	s := strings.Join(links, "\n")
+	w, err := os.Create(filename)
+	if err != nil {
+		fmt.Printf("Error creating file: %s", err)
+	}
+	io.WriteString(w, s)
+}

--- a/rtoa.go
+++ b/rtoa.go
@@ -7,6 +7,10 @@ func rtoa(url string, host string) string {
 	if strings.HasPrefix(url, "http") {
 		return url
 	} else {
-		return httpify(host + url)
+		if strings.HasPrefix(url, "/") {
+			return httpify(host + url)
+		} else {
+			return httpify(host + "/" + url)
+		}
 	}
 }

--- a/rtoa.go
+++ b/rtoa.go
@@ -4,6 +4,7 @@ import "strings"
 
 // Converts a relative URL to an absolute one.
 func rtoa(url string, host string) string {
+	host = strings.TrimSuffix(host, "/")
 	if strings.HasPrefix(url, "http") {
 		return url
 	} else {

--- a/rtoa.go
+++ b/rtoa.go
@@ -1,0 +1,12 @@
+package main
+
+import "strings"
+
+// Converts a relative URL to an absolute one.
+func rtoa(url string, host string) string {
+	if strings.HasPrefix(url, "http") {
+		return url
+	} else {
+		return httpify(host + url)
+	}
+}


### PR DESCRIPTION
What it says on the tin. :)
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 0ce59325e954879100a6a138527d99eef53f8a9e  | 
|--------|--------|

### Summary:
Added functionality to traverse and extract links from a webpage up to a specified depth, including new command-line arguments, recursive fetching, and rendering of results.

**Key points**:
- Added `const.go` to define constants `DEPTH` and `LINKS_PER_PAGE`.
- Modified `extractLinks.go` to include `extractLinksClosure` and refactor `extractLinks` to use it.
- Updated `fetchHtml.go` to return both the root node and hostname.
- Introduced `fetchHtmlAndLinks.go` to fetch HTML and links recursively up to a specified depth.
- Updated `main.go` to parse new command-line arguments and handle depth traversal.
- Added `mkOutDir.go` to create an output directory if it doesn't exist.
- Added `parseArgs.go` to handle command-line argument parsing for URL, depth, and links per page.
- Updated `renderHtml.go` to include the URL as a comment in the rendered HTML file.
- Added `renderLinks.go` to render extracted links to a file.
- Added `rtoa.go` to convert relative URLs to absolute ones.
- Updated `makefile` to include `clean` and `clean-out` targets.
- Updated `milestones.txt` to mark the depth extraction milestone as complete.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->